### PR TITLE
byte array mapping fixes

### DIFF
--- a/include/hedera-transaction-contract-call.h
+++ b/include/hedera-transaction-contract-call.h
@@ -15,7 +15,7 @@ extern void hedera_transaction__contract_call__set_gas(HederaTransaction*, uint6
 extern void hedera_transaction__contract_call__set_amount(HederaTransaction*, uint64_t amount);
 
 extern void hedera_transaction__contract_call__set_function_parameters(
-    HederaTransaction*, const uint8_t* parameters);
+    HederaTransaction*, const uint8_t* parameters, usize_t parameters_len);
 
 #ifdef __cplusplus
 }

--- a/include/hedera-transaction-contract-create.h
+++ b/include/hedera-transaction-contract-create.h
@@ -31,7 +31,7 @@ extern void hedera_transaction__contract_create__set_auto_renew_period(
     HederaTransaction*, HederaDuration period);
 
 extern void hedera_transaction__contract_create__set_constructor_parameters(
-    HederaTransaction*, const uint8_t* parameters);
+    HederaTransaction*, const uint8_t* parameters, usize_t parameters_t);
 
 #ifdef __cplusplus
 }

--- a/include/hedera-transaction-file-append.h
+++ b/include/hedera-transaction-file-append.h
@@ -9,7 +9,7 @@ extern "C" {
 #endif
 
 extern HederaTransaction* hedera_transaction__file_append__new(
-    HederaClient*, HederaFileId id, const uint8_t* contents);
+    HederaClient*, HederaFileId id, const uint8_t* contents, size_t contents_len);
 
 #ifdef __cplusplus
 }

--- a/include/hedera-transaction-file-create.h
+++ b/include/hedera-transaction-file-create.h
@@ -14,7 +14,7 @@ extern void hedera_transaction__file_create__set_key(
     HederaTransaction*, HederaPublicKey key);
 
 extern void hedera_transaction__file_create__set_contents(
-    HederaTransaction*, const uint8_t* contents);
+    HederaTransaction*, const uint8_t* content, size_t content_len);
 
 extern void hedera_transaction__file_create__set_expires_at(
     HederaTransaction*, HederaTimestamp expiration);

--- a/include/hedera-transaction-file-update.h
+++ b/include/hedera-transaction-file-update.h
@@ -13,7 +13,7 @@ extern HederaTransaction* hedera_transaction__file_update__new(HederaClient*, He
 extern void hedera_transaction__file_update__set_key(HederaTransaction*, HederaPublicKey key);
 
 extern void hedera_transaction__file_update__set_contents(
-    HederaTransaction*, const uint8_t* contents);
+    HederaTransaction*, const uint8_t* contents, size_t contents_len);
 
 #ifdef __cplusplus
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -108,6 +108,23 @@ macro_rules! def_tx_new {
         }
     };
 
+    ($constructor:ident: $name:ident(array_of($ty:ty))) => {
+        use std::slice;
+
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(
+            client: *mut hedera::Client,
+            _1: *const $ty,
+            _1_len: usize
+        ) -> *mut hedera::transaction::Transaction<$constructor> {
+
+            let _1 = slice::from_raw_parts(_1, _1_len);
+
+            Box::into_raw(Box::new($constructor::new(&*client, _1.into())))
+        }
+    };
+
+
     ($constructor:ident: $name:ident($ty:ty)) => {
         #[no_mangle]
         pub unsafe extern "C" fn $name(
@@ -115,6 +132,22 @@ macro_rules! def_tx_new {
             _1: $ty,
         ) -> *mut hedera::transaction::Transaction<$constructor> {
             Box::into_raw(Box::new($constructor::new(&*client, _1.into())))
+        }
+    };
+
+    ($constructor:ident: $name:ident($p1:ty, array_of($p2:ty))) => {
+        use std::slice;
+
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(
+            client: *mut hedera::Client,
+            _1: $p1,
+            _2: *const $p2,
+            _2_len: usize
+        ) -> *mut hedera::transaction::Transaction<$constructor> {
+            let _2 = slice::from_raw_parts(_2, _2_len);
+
+            Box::into_raw(Box::new($constructor::new(&*client, _1.into(), _2.into())))
         }
     };
 
@@ -128,10 +161,26 @@ macro_rules! def_tx_new {
             Box::into_raw(Box::new($constructor::new(&*client, _1.into(), _2.into())))
         }
     };
+
 }
 
 #[macro_export]
 macro_rules! def_tx_method {
+    ($constructor:ident: $name:ident(array_of($ty:ty)): $member:ident) => {
+        use std::slice;
+
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(
+            tx: *mut hedera::transaction::Transaction<$constructor>,
+            _1: *const $ty,
+            _1_len: usize
+        ) {
+            let _1 = slice::from_raw_parts(_1, _1_len);
+
+            (&mut *tx).$member(_1.into());
+        }
+    };
+
     ($constructor:ident: $name:ident($ty:ty): $member:ident) => {
         #[no_mangle]
         pub unsafe extern "C" fn $name(
@@ -139,6 +188,23 @@ macro_rules! def_tx_method {
             _1: $ty,
         ) {
             (&mut *tx).$member(_1.into());
+        }
+    };
+    
+    ($constructor:ident: $name:ident($p1:ty, array_of($p2:ty)): $member:ident) => {
+        use std::slice;
+
+        #[no_mangle]
+        pub unsafe extern "C" fn $name(
+            tx: *mut hedera::transaction::Transaction<$constructor>,
+            _1: $p1,
+            _2: *const $p2,
+            _2_len: usize
+        ) {
+
+            let _2 = slice::from_raw_parts(_2, _2_len);
+
+            (&mut *tx).$member(_1.into(), _2.into());
         }
     };
 
@@ -149,7 +215,9 @@ macro_rules! def_tx_method {
             _1: $p1,
             _2: $p2,
         ) {
+
             (&mut *tx).$member(_1.into(), _2.into());
         }
     };
+
 }

--- a/src/transaction_contract_call.rs
+++ b/src/transaction_contract_call.rs
@@ -8,6 +8,6 @@ def_tx_method!(TransactionContractCall: hedera_transaction__contract_call__set_g
 def_tx_method!(TransactionContractCall: hedera_transaction__contract_call__set_amount(i64): amount);
 
 def_tx_method!(
-    TransactionContractCall: hedera_transaction__contract_call__set_function_parameters(Vec<u8>):
+    TransactionContractCall: hedera_transaction__contract_call__set_function_parameters(array_of(u8)):
         function_parameters
 );

--- a/src/transaction_contract_create.rs
+++ b/src/transaction_contract_create.rs
@@ -40,8 +40,7 @@ def_tx_method!(
 
 def_tx_method!(
     TransactionContractCreate:
-        hedera_transaction__contract_create__set_constructor_parameters(Vec<u8>):
+        hedera_transaction__contract_create__set_constructor_parameters(array_of(u8)):
         constructor_parameters
 );
 
-// todo: to proto

--- a/src/transaction_crypto_add_claim.rs
+++ b/src/transaction_crypto_add_claim.rs
@@ -2,7 +2,7 @@ use hedera::transaction::TransactionCryptoAddClaim;
 use hedera::{AccountId, PublicKey};
 
 def_tx_new!(
-    TransactionCryptoAddClaim: hedera_transaction__crypto_add_claim__new(AccountId, Vec<u8>)
+    TransactionCryptoAddClaim: hedera_transaction__crypto_add_claim__new(AccountId, array_of(u8))
 );
 
 def_tx_method!(

--- a/src/transaction_file_append.rs
+++ b/src/transaction_file_append.rs
@@ -1,4 +1,4 @@
 use hedera::transaction::TransactionFileAppend;
 use hedera::FileId;
 
-def_tx_new!(TransactionFileAppend: hedera_transaction__file_append__new(FileId, Vec<u8>));
+def_tx_new!(TransactionFileAppend: hedera_transaction__file_append__new(FileId, array_of(u8)));

--- a/src/transaction_file_create.rs
+++ b/src/transaction_file_create.rs
@@ -9,8 +9,4 @@ def_tx_method!(TransactionFileCreate: hedera_transaction__file_create__set_expir
 
 def_tx_method!(TransactionFileCreate: hedera_transaction__file_create__set_key(PublicKey): key);
 
-<<<<<<< HEAD
-def_tx_method!(TransactionFileCreate: hedera_transaction__file_create__set_contents(Vec<u8>): contents);
-=======
 def_tx_method!(TransactionFileCreate: hedera_transaction__file_create__set_contents(array_of(u8)): contents);
->>>>>>> corrects mappings of byte arrays

--- a/src/transaction_file_create.rs
+++ b/src/transaction_file_create.rs
@@ -2,10 +2,15 @@ use crate::timestamp::CTimestamp;
 use hedera::transaction::TransactionFileCreate;
 use hedera::PublicKey;
 
+
 def_tx_new!(TransactionFileCreate: hedera_transaction__file_create__new);
 
 def_tx_method!(TransactionFileCreate: hedera_transaction__file_create__set_expires_at(CTimestamp): expires_at);
 
 def_tx_method!(TransactionFileCreate: hedera_transaction__file_create__set_key(PublicKey): key);
 
+<<<<<<< HEAD
 def_tx_method!(TransactionFileCreate: hedera_transaction__file_create__set_contents(Vec<u8>): contents);
+=======
+def_tx_method!(TransactionFileCreate: hedera_transaction__file_create__set_contents(array_of(u8)): contents);
+>>>>>>> corrects mappings of byte arrays

--- a/src/transaction_file_update.rs
+++ b/src/transaction_file_update.rs
@@ -9,5 +9,5 @@ def_tx_new!(TransactionFileUpdate: hedera_transaction__file_update__new(FileId))
 def_tx_method!(TransactionFileUpdate: hedera_transaction__file_update__set_key(PublicKey): key);
 
 def_tx_method!(
-    TransactionFileUpdate: hedera_transaction__file_Update__set_contents(Vec<u8>): contents
+    TransactionFileUpdate: hedera_transaction__file_Update__set_contents(array_of(u8)): contents
 );


### PR DESCRIPTION
Introduces new macro patterns for handling arrays in transactions and corrects the c header files to match.

fixes: hashgraph/hedera-sdk-rust#63